### PR TITLE
Use structured logging in map pipeline

### DIFF
--- a/apps/mcp/tools/map/pipeline.ts
+++ b/apps/mcp/tools/map/pipeline.ts
@@ -4,6 +4,7 @@ import type {
   MapResult,
 } from "@firecrawl/client";
 import type { MapOptions } from "./schema.js";
+import { logDebug } from "../../utils/logging.js";
 
 export async function mapPipeline(
   client: FirecrawlMapClient,
@@ -20,18 +21,11 @@ export async function mapPipeline(
     location: options.location,
   };
 
-  console.log(
-    "[DEBUG] Map pipeline options:",
-    JSON.stringify(clientOptions, null, 2),
-  );
+  logDebug("mapPipeline", "Map pipeline options", { clientOptions });
   const result = await client.map(clientOptions);
-  console.log(
-    "[DEBUG] Map pipeline result:",
-    JSON.stringify(
-      { success: result.success, linksCount: result.links?.length || 0 },
-      null,
-      2,
-    ),
-  );
+  logDebug("mapPipeline", "Map pipeline result", {
+    success: result.success,
+    linksCount: result.links?.length || 0,
+  });
   return result;
 }


### PR DESCRIPTION
## Summary
- replace direct console logging in the map pipeline with the shared structured logger guarded by the existing debug flag

## Testing
- pnpm vitest run tools/map

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69129cf4f29083298966d9afaf42c2d2)