### PR TITLE
Add CI workflow for pnpm and uv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v1
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Cache uv
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that configures Node.js/pnpm and Python/uv toolchains
- cache pnpm store and uv environments to improve run times
- run tests, linting, and type checking on pushes and pull requests targeting main

## Testing
- not run (not run)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69129c6ee4888329bf5eee499127fac8)